### PR TITLE
[FIX #82015] Connecteur Cybermut - async bill validation

### DIFF
--- a/actions/BankCancelCybermutAction.class.php
+++ b/actions/BankCancelCybermutAction.class.php
@@ -25,7 +25,7 @@ class payment_BankCancelCybermutAction extends f_action_BaseAction
 				throw new Exception('Session expired');
 			}
 
-					$params = array();
+			$params = array();
 			$params['orderId'] = $request->getParameter('orderId');
 			$params['connectorId'] = $request->getParameter('connectorId');
 			$params['lang'] = $request->getParameter('lang');
@@ -41,7 +41,7 @@ class payment_BankCancelCybermutAction extends f_action_BaseAction
 			{
 				$connectorService->setPaymentResult($bankResponse, $order);
 			}
-			elseif ($order->getPaymentStatus() === 'initiated')
+			elseif (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated')
 			{
 				$ms->log("BANKING CYBERMUT from [" . $remoteAddr . " : " . $requestUri . "] UPDATE STATUS: FAILED");
 				$connectorService->setPaymentResult($bankResponse, $order);

--- a/actions/BankListenerCybermutAction.class.php
+++ b/actions/BankListenerCybermutAction.class.php
@@ -22,24 +22,86 @@ class payment_BankListenerCybermutAction extends f_action_BaseAction
 	 */
 	public function _execute($context, $request)
 	{
-	    $remoteAddr = $_SERVER['REMOTE_ADDR'];
-        $requestUri = $_SERVER['REQUEST_URI'];
-		$ms = payment_ModuleService::getInstance();	
-		$ms->log("BANKING CYBERMUT LISTENER from [".$remoteAddr." : ".$requestUri."] BEGIN");	
-		
+		$remoteAddr = $_SERVER['REMOTE_ADDR'];
+		$requestUri = $_SERVER['REQUEST_URI'];
+		$ms = payment_ModuleService::getInstance();
+		$ms->log("BANKING CYBERMUT LISTENER from [".$remoteAddr." : ".$requestUri."] BEGIN");
+
 		try
 		{
 			$this->getTransactionManager()->beginTransaction();
-			
-			$connectorService = payment_CybermutconnectorService::getInstance();       
-			$bankResponse = $connectorService->getBankResponse($request->getParameters());			
+
+			$connectorService = payment_CybermutconnectorService::getInstance();
+			$bankResponse = $connectorService->getBankResponse($request->getParameters());
 			if ($bankResponse->getTransactionId() == null)
 			{
 				throw new Exception("CYBERMUT BANKING FAILED : BAD MAC CHECKING");
 			}
 			$order = $bankResponse->getOrder();
-			$connectorService->setPaymentResult($bankResponse, $order);
-					
+
+			$taskId = $order->getMeta('taskId');
+			if($taskId)
+			{
+				$task = DocumentHelper::getDocumentInstance($taskId);
+				if(!$task->isPublished())
+				{
+					Framework::error(__METHOD__.": payment task $taskId already executed");
+					$ms->log("BANKING CYBERMUT TASK : payment task $taskId already executed");
+					$task = null;
+				}
+
+				if($task->getIsrunning())
+				{
+					Framework::error(__METHOD__.": payment task $taskId is running");
+					$ms->log("BANKING CYBERMUT TASK : payment task $taskId is running");
+					$task = null;
+				}
+			}
+
+			if($task)
+			{
+				if($bankResponse->isAccepted())
+				{
+					// la validation de paiement se fera 5 minutes plus tard pour ne pas être en conflit avec le traitement
+					// sur la page de retour de la banque (payment_BankResponseCybermutAction)
+					$date = date_Calendar::getInstance()->add(date_Calendar::MINUTE, 5);
+					$task->setUniqueExecutiondate($date);
+				}
+				$task->setParameters(serialize(array('bankResponse' => $bankResponse)));
+				f_persistentdocument_PersistentProvider::getInstance()->updateDocument($task);
+				$ms->log("BANKING CYBERMUT TASK : update payment task $taskId");
+			}
+			else
+			{
+				if($bankResponse->isAccepted())
+				{
+					// la validation de paiement se fera 5 minutes plus tard pour ne pas être en conflit avec le traitement
+					// sur la page de retour de la banque (payment_BankResponseCybermutAction)
+					$date = date_Calendar::getInstance()->add(date_Calendar::MINUTE, 5);
+				}
+				else
+				{
+					// selon la FAQ dans la documentation technique, l'internaute dispose de 45 minutes pour saisir le numéro CB
+					// https://www.cmcicpaiement.fr/fr/installation/telechargements/index.html
+					$date = date_Calendar::getInstance()->add(date_Calendar::MINUTE, 60);
+				}
+
+				$task = task_PlannedtaskService::getInstance()->getNewDocumentInstance();
+				$task->setSystemtaskclassname('payment_CybermutPaymentResult');
+				$task->setLabel(__METHOD__);
+				$task->setUniqueExecutiondate($date);
+				$task->setParameters(serialize(array('bankResponse' => $bankResponse)));
+				$task->save();
+				$order->setMeta('taskId', $task->getId());
+				$order->saveMeta();
+				$ms->log("BANKING CYBERMUT TASK : create payment task $taskId");
+			}
+
+			if (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated')
+			{
+				$order->setPaymentStatus('waiting');
+			}
+
 			$ms->log("BANKING CYBERMUT LISTENER from [".$remoteAddr." : ".$requestUri."] END");
 			$this->getTransactionManager()->commit();
 		}
@@ -47,22 +109,22 @@ class payment_BankListenerCybermutAction extends f_action_BaseAction
 		{
 			$ms->log("BANKING CYBERMUT LISTENER from [".$remoteAddr." : ".$requestUri."] FAILED : " . $e->getMessage());
 			$this->getTransactionManager()->rollBack($e);
-			
+
 			header("Pragma: no-cache");
 			header("Content-type: text/plain");
-    		$receipt = CMCIC_CGI2_MACNOTOK.$bankResponse->getRawBankResponse();
-    		printf (CMCIC_CGI2_RECEIPT, $receipt);
-    		exit();
+			$receipt = CMCIC_CGI2_MACNOTOK.$bankResponse->getRawBankResponse();
+			printf (CMCIC_CGI2_RECEIPT, $receipt);
+			exit();
 		}
-		
-		ob_get_clean();		
+
+		ob_get_clean();
 		header("Pragma: no-cache");
 		header("Content-type: text/plain");
-    	$receipt = CMCIC_CGI2_MACOK;
-    	printf (CMCIC_CGI2_RECEIPT, $receipt);
+		$receipt = CMCIC_CGI2_MACOK;
+		printf (CMCIC_CGI2_RECEIPT, $receipt);
 		exit();
 	}
-	
+
 	/**
 	 * @return Integer
 	 */

--- a/actions/BankListenerCybermutAction.class.php
+++ b/actions/BankListenerCybermutAction.class.php
@@ -99,7 +99,9 @@ class payment_BankListenerCybermutAction extends f_action_BaseAction
 
 			if (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated')
 			{
-				$order->setPaymentStatus('waiting');
+				$bankResponse->setDelayed();
+				$bankResponse->setTransactionText(f_Locale::translate('&modules.payment.document.cybermutconnector.Transaction-delayed;'));
+				$connectorService->setPaymentResult($bankResponse, $order);
 			}
 
 			$ms->log("BANKING CYBERMUT LISTENER from [".$remoteAddr." : ".$requestUri."] END");

--- a/actions/BankResponseCybermutAction.class.php
+++ b/actions/BankResponseCybermutAction.class.php
@@ -52,7 +52,9 @@ class payment_BankResponseCybermutAction extends f_action_BaseAction
 			if (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated')
 			{
 				$ms->log("BANKING CYBERMUT from [" . $remoteAddr . " : " . $requestUri . "] UPDATE STATUS: WAITING");
-				$order->setPaymentStatus('waiting');
+				$bankResponse->setDelayed();
+				$bankResponse->setTransactionText(f_Locale::translate('&modules.payment.document.cybermutconnector.Transaction-delayed;'));
+				$connectorService->setPaymentResult($bankResponse, $order);
 			}
 
 			$url = $sessionInfo['paymentURL'];

--- a/actions/BankResponseCybermutAction.class.php
+++ b/actions/BankResponseCybermutAction.class.php
@@ -40,9 +40,16 @@ class payment_BankResponseCybermutAction extends f_action_BaseAction
 			//En production le listener ce charge de compléter la commande
 			if (Framework::inDevelopmentMode())
 			{
-				$connectorService->setPaymentResult($bankResponse, $order);
+				$date = date_Calendar::getInstance()->add(date_Calendar::MINUTE, 5);
+				$task = task_PlannedtaskService::getInstance()->getNewDocumentInstance();
+				$task->setSystemtaskclassname('payment_CybermutPaymentResult');
+				$task->setLabel(__METHOD__);
+				$task->setUniqueExecutiondate($date);
+				$task->setParameters(serialize(array('bankResponse' => $bankResponse)));
+				$task->save();
 			}
-			elseif ($order->getPaymentStatus() === 'initiated')
+
+			if (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated')
 			{
 				$ms->log("BANKING CYBERMUT from [" . $remoteAddr . " : " . $requestUri . "] UPDATE STATUS: WAITING");
 				$order->setPaymentStatus('waiting');

--- a/lib/tasks/CybermutPaymentResult.class.php
+++ b/lib/tasks/CybermutPaymentResult.class.php
@@ -1,0 +1,48 @@
+<?php
+class payment_CybermutPaymentResult extends task_SimpleSystemTask
+{
+	/**
+	 * @see task_SimpleSystemTask::execute()
+	 *
+	 */
+	protected function execute()
+	{
+		$ms = payment_ModuleService::getInstance();
+
+		try
+		{
+			/* @var $bankResponse payment_Transaction */
+			$bankResponse= $this->getParameter('bankResponse');
+			$order = $bankResponse->getOrder();
+		}
+		catch (Exception $e)
+		{
+			$ms->log("BANKING CYBERMUT TASK : task: ".$this->plannedTask->getId().", ORDER NOT FOUND");
+			throw $e;
+		}
+
+		if (f_util_StringUtils::isEmpty($order->getPaymentStatus()) || $order->getPaymentStatus() === 'initiated' || $order->getPaymentStatus() === 'waiting')
+		{
+			$tm = f_persistentdocument_TransactionManager::getInstance();
+			try
+			{
+				$tm->beginTransaction();
+
+				$connectorService = payment_CybermutconnectorService::getInstance();
+				$connectorService->setPaymentResult($bankResponse, $order);
+				$ms->log("BANKING CYBERMUT TASK : task: ".$this->plannedTask->getId().", order: ".$order->getId().", STATUS: ".$order->getPaymentStatus());
+
+				$tm->commit();
+			}
+			catch (Exception $e)
+			{
+				$ms->log("BANKING CYBERMUT TASK : task: ".$this->plannedTask->getId().", order: ".$order->getId().", ERROR: ".$e->getMessage());
+				$tm->rollBack($e);
+			}
+		}
+		else
+		{
+			$ms->log("BANKING CYBERMUT TASK : task: ".$this->plannedTask->getId().", order: ".$order->getId().", SKIP: transaction already handled");
+		}
+	}
+}


### PR DESCRIPTION
Il est possible d'avoir un conflit dans la modification de statut de la facture entre le listener et la page de retour. Pour éviter le conflit, le traitement de statut de la facture se fait de manière asynchrone.
